### PR TITLE
fix: 유저가 입력한 alignment가 적용되지 않음

### DIFF
--- a/lib/src/swiper_pagination.dart
+++ b/lib/src/swiper_pagination.dart
@@ -284,17 +284,14 @@ class SwiperPagination extends SwiperPlugin {
 
   @override
   Widget build(BuildContext context, SwiperPluginConfig? config) {
-    final alignment = config!.scrollDirection == Axis.horizontal
-        ? Alignment.bottomCenter
-        : Alignment.centerRight;
     Widget child = Container(
       margin: margin,
-      child: builder.build(context, config),
+      child: builder.build(context, config!),
     );
     if (!config.outer!) {
       child = Align(
         key: key,
-        alignment: alignment,
+        alignment: alignment!,
         child: child,
       );
     }


### PR DESCRIPTION
[MOB-457]

build 단계에서 유저가 입력한 alignment 대신 scrollDirection에따라 새로 넣음 

https://app.asana.com/0/1200444945937367/1200477089345299

[MOB-457]: https://dietfriends.atlassian.net/browse/MOB-457